### PR TITLE
feat(ui5_create_app): Always set "earlyRequests": true in UI5 >=1.141

### DIFF
--- a/resources/template-js/webapp/manifest.json
+++ b/resources/template-js/webapp/manifest.json
@@ -68,7 +68,7 @@
 				"dataSource": "default",
 				"preload": true,
 				"settings": {
-					"autoExpandSelect": true,<% if (serverRequiresXCSRF) { %>
+					"autoExpandSelect": true,<% if (serverRequiresXCSRF || gte1_141_0) { %>
 					"earlyRequests": true,<% } %>
 					"operationMode": "Server"<% if (lt1_110_0) { %>,
 					"synchronizationMode": "None"<% } %>

--- a/resources/template-ts/webapp/manifest.json
+++ b/resources/template-ts/webapp/manifest.json
@@ -70,7 +70,7 @@
 				"dataSource": "default",
 				"preload": true,
 				"settings": {
-					"autoExpandSelect": true,<% if (serverRequiresXCSRF) { %>
+					"autoExpandSelect": true,<% if (serverRequiresXCSRF || gte1_141_0) { %>
 					"earlyRequests": true,<% } %>
 					"operationMode": "Server"<% if (lt1_110_0) { %>,
 					"synchronizationMode": "None"<% } %>

--- a/src/tools/create_ui5_app/create_ui5_app.ts
+++ b/src/tools/create_ui5_app/create_ui5_app.ts
@@ -237,6 +237,7 @@ The minimum version for ${framework} is ${minFwkVersionToUse}.`
 		gte1_115_0: semver.gte(frameworkVersion, "1.115.0"),
 		gte1_120_0: semver.gte(frameworkVersion, "1.120.0"),
 		lt1_124_0: semver.lt(frameworkVersion, "1.124.0"),
+		gte1_141_0: semver.gte(frameworkVersion, "1.141.0"),
 	};
 
 	// Process template files

--- a/src/tools/create_ui5_app/templateProcessor.ts
+++ b/src/tools/create_ui5_app/templateProcessor.ts
@@ -46,6 +46,7 @@ export interface TemplateVars {
 	gte1_115_0: boolean;
 	gte1_120_0: boolean;
 	lt1_124_0: boolean;
+	gte1_141_0: boolean;
 }
 
 /**

--- a/test/lib/tools/create_ui5_app/create_ui5_app.ts
+++ b/test/lib/tools/create_ui5_app/create_ui5_app.ts
@@ -172,6 +172,7 @@ test("All parameters", async (t) => {
 			gte1_98_0: true,
 			lt1_110_0: false,
 			lt1_124_0: false,
+			gte1_141_0: false,
 			namespace: "com.test.apiapp",
 			oDataEntitySet: "Products",
 			oDataV4Url: "https://localhost/odata/v4/service/",


### PR DESCRIPTION
The models team enabled having this setting always as "true" in https://github.com/UI5/openui5/commit/6c7fb695adb18385c887afa9fc462aa471555cd4, from UI5 1.141 onwards. "true" improves performance in many cases and is hence appropriate for a best-practice template.
The topic was originally discussed in https://github.com/UI5/openui5/issues/2288