### PR TITLE
Revert "ci(coveralls): Workaround for 500 server errors"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,3 @@ jobs:
 
     - name: Send report to Coveralls
       uses: coverallsapp/github-action@v2
-      with:
-        # Pinned to v0.6.15 as workaround for 500 server errors
-        # See: https://github.com/coverallsapp/coverage-reporter/issues/180
-        coverage-reporter-version: v0.6.15


### PR DESCRIPTION
Reverts UI5/mcp-server#51

Issue has been resolved:
https://github.com/coverallsapp/coverage-reporter/issues/180