### PR TITLE
ci(github-actions): Ignore Coveralls errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,4 @@ jobs:
 
     - name: Send report to Coveralls
       uses: coverallsapp/github-action@v2
-      with:
-        # Pinned to v0.6.15 as workaround for 500 server errors
-        # See: https://github.com/coverallsapp/coverage-reporter/issues/180
-        coverage-reporter-version: v0.6.15
+      continue-on-error: true # Do not fail the job if coverage reporting fails (e.g. service is down)


### PR DESCRIPTION
This will add `continue-on-error` to the Coveralls report upload step in the job "CI / General checks...".
In case of an error with this step (e.g. the Coveralls service is temporarily down) the job continues as normal and does NOT fail.