### PR TITLE
fix(package.json): Skip prepare script if installing from tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"knip": "knip --config knip.config.js",
 		"hooks:pre-push": "npm run lint:commit && npm run lint && npm run knip",
 		"lint:commit": "commitlint -e",
-		"prepare": "node ./.husky/skip.js || husky",
+		"prepare": "test -f ./.husky/skip.js && node ./.husky/skip.js || test -d ./.git && husky || true",
 		"clean-coverage": "rimraf coverage",
 		"clean-lib": "rimraf lib",
 		"clean-test-tmp": "rimraf test/tmp",


### PR DESCRIPTION
As per https://docs.npmjs.com/cli/v8/using-npm/scripts the `prepare` script is also executed when running `npm install` inside the unpacked tarball which is missing the custom `.husky/skip.js` file as well as the `.git` directory, which is expected by `husky` itself.

Fixes https://github.com/UI5/mcp-server/issues/287
