### PR TITLE
feat: Add UI5_MCP_SERVER_CDN_URL env var to override CDN base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ The UI5 MCP server can be configured using the following environment variables. 
     * Description: Set to any value to disable structured content in the MCP server responses.
 * **`UI5_MCP_SERVER_RESPONSE_NO_RESOURCES`**:
     * Description: Set to any value to disable [resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources) in the MCP server responses. This is useful for [clients that do not support resources](https://modelcontextprotocol.io/clients), such as Cursor or the Gemini CLI.
+* **`UI5_MCP_SERVER_CDN_URL`**:
+    * Default Value: `https://sdk.openui5.org` for OpenUI5 and `https://ui5.sap.com` for SAPUI5
+    * Description: Override the base URL used for fetching UI5 resources from the CDN. For example: `https://example.com`. When set, this URL is used for both OpenUI5 and SAPUI5 resources. The value must be a valid URL. Note that the project's version will appended to the URL automatically. This means that at runtime, the URL might look like this: `https://example.com/1.120.0/resources/[...]`.
 * **`UI5_LOG_LVL`**:
     * Default Value: `info`
     * Description: Internal [log level](https://ui5.github.io/cli/stable/pages/Troubleshooting/#changing-the-log-level): `silent`, `error`, `warn`, `info`, `perf`, `verbose`, `silly`

--- a/src/utils/cdnHelper.ts
+++ b/src/utils/cdnHelper.ts
@@ -1,6 +1,33 @@
 import fetch from "make-fetch-happen";
+import {getLogger} from "@ui5/logger";
 import {InvalidInputError} from "../utils.js";
 import {Ui5Framework} from "./ui5Framework.js";
+
+const log = getLogger("utils:cdnHelper");
+
+function getCustomCdnUrl(): string | undefined {
+	const value = process.env.UI5_MCP_SERVER_CDN_URL;
+	if (!value) {
+		return undefined;
+	}
+	let url = value.trim();
+	if (!url) {
+		return undefined;
+	}
+	// Strip trailing slashes
+	url = url.replace(/\/+$/, "");
+	// Validate URL format
+	try {
+		new URL(url);
+	} catch {
+		throw new InvalidInputError(
+			`Invalid URL '${value}' in UI5_MCP_SERVER_CDN_URL: ` +
+			`The value must be a valid URL (e.g., "https://my-cdn.example.com")`
+		);
+	}
+	log.info(`Using custom CDN URL from UI5_MCP_SERVER_CDN_URL: ${url}`);
+	return url;
+}
 
 /**
  * Get the base URL for the UI5 CDN based on the framework
@@ -8,19 +35,21 @@ import {Ui5Framework} from "./ui5Framework.js";
  * @returns The CDN base URL
  */
 export function getBaseUrl(frameworkName: Ui5Framework, frameworkVersion?: string): string {
-	let baseUrl;
-	switch (frameworkName) {
-		case "OpenUI5":
-			baseUrl = "https://sdk.openui5.org";
-			break;
-		case "SAPUI5":
-			baseUrl = "https://ui5.sap.com";
-			break;
-		default:
-			// This should never happen due to TypeScript's type checking,
-			// but we handle it anyway for runtime safety
-			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-			throw new InvalidInputError(`Unknown framework: ${frameworkName}`);
+	let baseUrl = getCustomCdnUrl();
+	if (!baseUrl) {
+		switch (frameworkName) {
+			case "OpenUI5":
+				baseUrl = "https://sdk.openui5.org";
+				break;
+			case "SAPUI5":
+				baseUrl = "https://ui5.sap.com";
+				break;
+			default:
+				// This should never happen due to TypeScript's type checking,
+				// but we handle it anyway for runtime safety
+				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+				throw new InvalidInputError(`Unknown framework: ${frameworkName}`);
+		}
 	}
 	if (frameworkVersion) {
 		baseUrl += `/${frameworkVersion}`;

--- a/test/lib/utils/cdnHelper.ts
+++ b/test/lib/utils/cdnHelper.ts
@@ -10,18 +10,31 @@ const test = anyTest as TestFn<{
 	fetchCdn: typeof import("../../../src/utils/cdnHelper.js").fetchCdn;
 	fetchCdnRaw: typeof import("../../../src/utils/cdnHelper.js").fetchCdnRaw;
 	fetchStub: sinonGlobal.SinonStub;
+	loggerMock: {
+		info: sinonGlobal.SinonStub;
+	};
+	originalEnv: NodeJS.ProcessEnv;
 }>;
 
 test.beforeEach(async (t) => {
 	t.context.sinon = sinonGlobal.createSandbox();
+	t.context.originalEnv = {...process.env};
 
 	// Create a stub for global fetch
 	const fetchStub = t.context.sinon.stub();
 	t.context.fetchStub = fetchStub;
 
+	const loggerMock = {
+		info: t.context.sinon.stub(),
+	};
+	t.context.loggerMock = loggerMock;
+
 	// Import the module with mocked dependencies
 	const {getBaseUrl, fetchCdn, fetchCdnRaw} = await esmock("../../../src/utils/cdnHelper.js", {
 		"make-fetch-happen": fetchStub,
+		"@ui5/logger": {
+			getLogger: t.context.sinon.stub().returns(loggerMock),
+		},
 	});
 
 	t.context.getBaseUrl = getBaseUrl;
@@ -30,11 +43,13 @@ test.beforeEach(async (t) => {
 });
 
 test.afterEach.always((t) => {
+	process.env = t.context.originalEnv;
 	t.context.sinon.restore();
 });
 
 test.serial("getBaseUrl returns correct URL for OpenUI5", (t) => {
 	const {getBaseUrl} = t.context;
+	delete process.env.UI5_MCP_SERVER_CDN_URL;
 
 	const url = getBaseUrl("OpenUI5");
 	t.is(url, "https://sdk.openui5.org");
@@ -42,6 +57,7 @@ test.serial("getBaseUrl returns correct URL for OpenUI5", (t) => {
 
 test.serial("getBaseUrl returns correct URL for SAPUI5", (t) => {
 	const {getBaseUrl} = t.context;
+	delete process.env.UI5_MCP_SERVER_CDN_URL;
 
 	const url = getBaseUrl("SAPUI5");
 	t.is(url, "https://ui5.sap.com");
@@ -49,6 +65,7 @@ test.serial("getBaseUrl returns correct URL for SAPUI5", (t) => {
 
 test.serial("getBaseUrl throws for unknown framework", (t) => {
 	const {getBaseUrl} = t.context;
+	delete process.env.UI5_MCP_SERVER_CDN_URL;
 
 	const error = t.throws(() => getBaseUrl("unknown-framework" as Ui5Framework));
 	t.true(error instanceof InvalidInputError);
@@ -57,9 +74,74 @@ test.serial("getBaseUrl throws for unknown framework", (t) => {
 
 test.serial("getBaseUrl appends version when provided", (t) => {
 	const {getBaseUrl} = t.context;
+	delete process.env.UI5_MCP_SERVER_CDN_URL;
 
 	const url = getBaseUrl("OpenUI5", "1.120.0");
 	t.is(url, "https://sdk.openui5.org/1.120.0");
+});
+
+test.serial("getBaseUrl uses custom CDN URL for OpenUI5", (t) => {
+	const {getBaseUrl, loggerMock} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "https://internal-mirror.corp.com";
+
+	const url = getBaseUrl("OpenUI5");
+	t.is(url, "https://internal-mirror.corp.com");
+	t.true(loggerMock.info.calledWith(
+		"Using custom CDN URL from UI5_MCP_SERVER_CDN_URL: https://internal-mirror.corp.com"
+	));
+});
+
+test.serial("getBaseUrl uses custom CDN URL for SAPUI5", (t) => {
+	const {getBaseUrl, loggerMock} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "https://internal-mirror.corp.com";
+
+	const url = getBaseUrl("SAPUI5");
+	t.is(url, "https://internal-mirror.corp.com");
+	t.true(loggerMock.info.calledWith(
+		"Using custom CDN URL from UI5_MCP_SERVER_CDN_URL: https://internal-mirror.corp.com"
+	));
+});
+
+test.serial("getBaseUrl appends version to custom CDN URL", (t) => {
+	const {getBaseUrl} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "https://internal-mirror.corp.com";
+
+	const url = getBaseUrl("OpenUI5", "1.120.0");
+	t.is(url, "https://internal-mirror.corp.com/1.120.0");
+});
+
+test.serial("getBaseUrl strips trailing slashes from custom CDN URL", (t) => {
+	const {getBaseUrl} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "https://internal-mirror.corp.com///";
+
+	const url = getBaseUrl("OpenUI5");
+	t.is(url, "https://internal-mirror.corp.com");
+});
+
+test.serial("getBaseUrl throws for invalid custom CDN URL", (t) => {
+	const {getBaseUrl} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "not-a-valid-url";
+
+	const error = t.throws(() => getBaseUrl("OpenUI5"));
+	t.true(error instanceof InvalidInputError);
+	t.regex(error.message, /Invalid URL 'not-a-valid-url' in UI5_MCP_SERVER_CDN_URL/);
+});
+
+test.serial("getBaseUrl ignores empty custom CDN URL and uses default", (t) => {
+	const {getBaseUrl, loggerMock} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "";
+
+	const url = getBaseUrl("OpenUI5");
+	t.is(url, "https://sdk.openui5.org");
+	t.false(loggerMock.info.called);
+});
+
+test.serial("getBaseUrl trims whitespace from custom CDN URL", (t) => {
+	const {getBaseUrl} = t.context;
+	process.env.UI5_MCP_SERVER_CDN_URL = "  https://internal-mirror.corp.com  ";
+
+	const url = getBaseUrl("SAPUI5");
+	t.is(url, "https://internal-mirror.corp.com");
 });
 
 test.serial("fetchCdnRaw returns response on success", async (t) => {


### PR DESCRIPTION
Allow users in restricted environments to override the default CDN URLs
for OpenUI5 and SAPUI5 with a custom mirror via a single environment
variable.

Fixes https://github.com/UI5/mcp-server/issues/293