### PR TITLE
ci: Harden workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -37,8 +37,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Install MCP Publisher
+      env:
+        MCP_PUBLISHER_VERSION: ${{ inputs.mcp_publisher_version || env.DEFAULT_MCP_PUBLISHER_VERSION }}
       run: |
-        MCP_PUBLISHER_VERSION="${{ inputs.mcp_publisher_version || env.DEFAULT_MCP_PUBLISHER_VERSION }}"
         MCP_PUBLISHER_OS_ARCH="$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
         MCP_PUBLISHER_DOWNLOAD_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${MCP_PUBLISHER_OS_ARCH}.tar.gz"
         curl -L "${MCP_PUBLISHER_DOWNLOAD_URL}" | tar xz mcp-publisher

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   pull-request:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}


### PR DESCRIPTION
- dependabot-auto-merge: gate on PR author login instead of github.actor,
  which can reflect a non-author triggering a later event on the PR.
- publish-mcp-registry: pass workflow_dispatch input via env var to avoid
  template expansion into the run block.
- release-please: scope contents/pull-requests write permissions to the
  pull-request job only; other jobs already declare their own scopes.
