### PR TITLE
fix(cli): support ui5mcp help flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,18 @@
 import Server from "./server.js";
 
-if (process.argv.length > 2) {
+function printUsage(): void {
+	process.stdout.write("Usage: ui5mcp\n");
+	process.stdout.write("\n");
+	process.stdout.write("Options:\n");
+	process.stdout.write("  -h, --help  Show this help message\n");
+}
+
+const args = process.argv.slice(2);
+
+if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+	printUsage();
+	process.exit(0);
+} else if (args.length > 0) {
 	process.stderr.write("\n");
 	process.stderr.write("Unexpected arguments: This command does not accept any arguments.\n");
 	process.stderr.write("Usage: ui5mcp\n");

--- a/test/lib/cli.ts
+++ b/test/lib/cli.ts
@@ -91,6 +91,35 @@ test.serial("CLI handles server connection errors", async (t) => {
 	t.true(serverInstance.connect.calledOnce);
 });
 
+test.serial("CLI prints help when help flag is provided", async (t) => {
+	const {sinon, exitStub} = t.context;
+
+	// Mock stdout.write to capture help output
+	const stdoutWriteStub = sinon.stub(process.stdout, "write");
+
+	// Add help flag to process.argv
+	process.argv.push("--help");
+
+	// Mock the Server import in cli - it shouldn't be called
+	await esmock("../../src/cli.js", {
+		"../../src/server.js": {
+			default: t.context.ServerConstructor,
+		},
+	});
+
+	// Verify process.exit was called with code 0
+	t.true(exitStub.calledOnce);
+	t.true(exitStub.calledWith(0));
+
+	// Verify usage was written to stdout
+	t.true(stdoutWriteStub.calledWith("Usage: ui5mcp\n"));
+	t.true(stdoutWriteStub.calledWith("Options:\n"));
+	t.true(stdoutWriteStub.calledWith("  -h, --help  Show this help message\n"));
+
+	// Verify Server constructor was not called
+	t.false(t.context.ServerConstructor.called);
+});
+
 test.serial("CLI exits with error when arguments are provided", async (t) => {
 	const {sinon, exitStub} = t.context;
 


### PR DESCRIPTION
## Summary
- allow `ui5mcp --help` and `ui5mcp -h` to print usage and exit successfully
- keep the existing no-argument server startup behavior unchanged
- keep unexpected arguments rejected with exit code 2

## Validation
- `npm run unit -- test/lib/cli.ts`
- `npm run build-test`
- `npm run build`
- `npm run lint -- --quiet src/cli.ts test/lib/cli.ts`
- `node .\bin\ui5mcp.js --help`