### PR TITLE
Add MCP Observatory CI

### DIFF
--- a/.github/workflows/mcp-observatory.yml
+++ b/.github/workflows/mcp-observatory.yml
@@ -1,0 +1,23 @@
+name: MCP Observatory
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  mcp-observatory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: KryptosAI/mcp-observatory/action@main
+        with:
+          target: mcp-observatory.target.json
+          deep: true
+          security: true
+          comment-on-pr: true

--- a/mcp-observatory.target.json
+++ b/mcp-observatory.target.json
@@ -1,0 +1,13 @@
+{
+  "targetId": "mcp-server",
+  "adapter": "local-process",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@ui5/mcp-server"
+  ],
+  "timeoutMs": 15000,
+  "metadata": {
+    "observatory": "generated-by-init-ci"
+  }
+}


### PR DESCRIPTION
## Add MCP Observatory CI

This adds a small MCP Observatory workflow for this MCP server.

Why it helps:

- verifies the MCP server starts and exposes its tool surface correctly
- catches schema drift and common security issues before release
- keeps the check local-first; no MCP Observatory account is required
- gives maintainers a PR-visible compatibility/security report

I validated the command locally with MCP Observatory before opening this PR:

```bash
npx @kryptosai/mcp-observatory test --security npx -y @ui5/mcp-server
```

Result: passed, with 10 tools discovered.

If this is too strict for the repo initially, the workflow can be adjusted while keeping the report visible.
