### PR TITLE
feat!: Remove deprecated MCP roots feature

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -761,8 +761,6 @@ If the data passed through the tool-parameters can trigger actions other than th
 	* Parameters that are passed to templating engines should be strictly validated to prevent command- and template injection attacks.
 * **Path Restriction:** All input paths must be normalized and validated
 	* For most tools, the provided path is supposed to be a valid UI5 project directory. This must be validated, for example by checking whether `@ui5/project` can create a UI5 project for the given path.
-	* If the MCP client supports the ["roots"](https://modelcontextprotocol.io/specification/2025-06-18/client/roots#roots)capability, UI5 MCP server must restrict the paths that can be accessed by the tool to the provided roots.
-		* As an exception to this rule, the UI5 MCP server will still write to its own cache directory, typically located in the `~/.ui5/mcp-server/` directory. This is necessary to store downloaded resources and other temporary data. See [Cache Management](#cache-management) for more details.
 
 ## Building and Testing
 

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,32 +1,16 @@
 import {realpath} from "fs/promises";
 import path, {isAbsolute} from "path";
 import {InvalidInputError} from "./utils.js";
-import {fileURLToPath} from "url";
-
-interface Root {
-	/**
-	 * @property uri - The unique identifier for the root, which must be a file:// URI.
-	*/
-	uri: string;
-	/**
-	 * @property name - An optional human-readable name for the root, used for display purposes.
-	*/
-	name?: string;
-}
-
-type Roots = Root[];
 
 export default class Context {
-	private allowedRootPaths: string[] = [];
-
 	constructor(private useStructuredContentInResponse = true, private useResourcesInResponse = true) {}
 
 	/**
-	 * Normalizes a path, ensuring it is absolute, exists, and is inside one of the configured roots (if configured).
+	 * Normalizes a path, ensuring it is absolute and exists.
 	 *
 	 * @param fsPath - The directory path to normalize.
 	 * @returns A promise that resolves to the normalized absolute path.
-	 * @throws InvalidInputError if the path is not absolute or not inside the allowed roots.
+	 * @throws InvalidInputError if the path is not absolute.
 	 */
 	async normalizePath(fsPath: string): Promise<string> {
 		// First normalize the path in order to safely check whether it is absolute
@@ -35,59 +19,9 @@ export default class Context {
 			throw new InvalidInputError(`Path must be absolute: ${fsPath}`);
 		}
 
-		// If roots are configured, already check whether the path is inside one of the roots before
-		// resolving it using the file system in order to prevent probing for the existence of files
-		// outside the roots
-		if (!this.isInsideRoots(absolutePath)) {
-			throw new InvalidInputError(
-				`Path must be inside an allowed root path: ${fsPath}.\n` +
-				`Currently configured roots: ${this.allowedRootPaths.map((rootPath) => rootPath).join(", ")}`);
-		}
 		// Get the actual location of the path on the file system:
 		// This checks whether the path exists and resolves any symbolic links.
 		// Note that realpath also accepts relative paths (and makes them absolute), hence the dedicated check above
-		const resolvedPath = await realpath(absolutePath);
-
-		// Ensure the resulting path is still inside one of the roots
-		if (!this.isInsideRoots(resolvedPath)) {
-			throw new InvalidInputError(
-				`Path must be inside an allowed root path: ${fsPath}.\n` +
-				`Currently configured roots: ${this.allowedRootPaths.map((rootPath) => rootPath).join(", ")}`);
-		}
-		return resolvedPath;
-	}
-
-	setRoots(roots: Roots) {
-		const newRoots = [];
-		for (const root of roots) {
-			let rootPath = fileURLToPath(root.uri);
-
-			// Ensure path ends in a slash since we only work with directories here
-			if (!rootPath.endsWith(path.sep)) {
-				rootPath += path.sep;
-			}
-			newRoots.push(rootPath);
-		}
-		// Always overwrite existing roots. Never append
-		this.allowedRootPaths = newRoots;
-	}
-
-	isInsideRoots(absolutePath: string): boolean {
-		if (!this.allowedRootPaths.length) {
-			return true;
-		}
-
-		// Ensure the path to be tested ends in a slash since the roots will always end in a slash
-		// Otherwise "/foo/bar" would not match a "/foo/bar/" root
-		if (!absolutePath.endsWith(path.sep)) {
-			absolutePath += path.sep;
-		}
-
-		return this.allowedRootPaths.some((rootPath) => {
-			if (process.platform === "win32") {
-				return absolutePath.toUpperCase().startsWith(rootPath.toUpperCase()); // case-insensitive due to Windows
-			}
-			return absolutePath.startsWith(rootPath);
-		});
+		return realpath(absolutePath);
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,10 +3,9 @@ import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
 import {Transport} from "@modelcontextprotocol/sdk/shared/transport.js";
 
 import Context from "./Context.js";
-import {ErrorCode, McpError, RootsListChangedNotificationSchema} from "@modelcontextprotocol/sdk/types.js";
 
 import {getLogger} from "@ui5/logger";
-import {handleError, PKG_VERSION} from "./utils.js";
+import {PKG_VERSION} from "./utils.js";
 import registerTools from "./registerTools.js";
 const log = getLogger("server");
 
@@ -45,68 +44,7 @@ export default class Server {
 		if (this.server.isConnected()) {
 			throw new Error("Server is already connected");
 		}
-		// eslint-disable-next-line @typescript-eslint/no-misused-promises -- See comment below
-		this.server.server.oninitialized = async () => {
-			// oninitialized is typed as not returning a promise, however the current code in the SDK
-			// still seems to handle it correctly, therefore we return a promise still and will raise an issue about
-			// async initialization handling
-			log.verbose("Client initialized");
-			try {
-				await this.handleServerInitialized();
-			} catch (err) {
-				handleError(err);
-			}
-		};
 		await this.server.connect(transport);
-	}
-
-	async handleServerInitialized() {
-		const clientCapabilities = this.server.server.getClientCapabilities();
-		if (!clientCapabilities?.roots) {
-			log.verbose("Client does not support roots capability");
-			return;
-		}
-		if (clientCapabilities?.roots?.listChanged) {
-			// Register handler for future updates to the roots list
-			this.server.server.setNotificationHandler(RootsListChangedNotificationSchema, async (notification) => {
-				if (notification.method !== "notifications/roots/list_changed") {
-					return;
-				}
-				try {
-					await this.updateRoots();
-				} catch (err) {
-					// We need to handle errors here since the MCP SDK currently seems to just swallow promise
-					// rejections in response handlers
-					handleError(err);
-				}
-			});
-		} else {
-			log.verbose("Client does not support issuing notifications for changed roots");
-		}
-		// Fetch the initial list of roots
-		await this.updateRoots();
-	}
-
-	async updateRoots() {
-		if (!this.server.isConnected()) {
-			throw new Error("Server is not connected");
-		}
-		try {
-			const res = await this.server.server.listRoots();
-			log.info(`Received ${res.roots.length} roots from client`);
-			log.verbose(`Setting roots in context: ${JSON.stringify(res.roots)}`);
-			this.context.setRoots(res.roots);
-		} catch (err) {
-			if (err instanceof McpError &&
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-				err.code === ErrorCode.MethodNotFound) {
-				// This error is produced by listRoots() if the client doesn't handle the request
-				// This indicates that it does not support roots, and can be ignored safely
-				log.verbose("Client does not implement roots/list request handler");
-			} else {
-				throw err;
-			}
-		}
 	}
 
 	async close() {

--- a/test/lib/Context.ts
+++ b/test/lib/Context.ts
@@ -1,11 +1,10 @@
 import anyTest, {TestFn} from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
-import {pathToFileURL} from "url";
 import path from "path";
 import {InvalidInputError} from "../../src/utils.js";
 
-const absoluteBasePath = path.join(process.cwd(), "test", "tmp", "roots");
+const absoluteBasePath = path.join(process.cwd(), "test", "tmp", "normalize-path");
 
 const test = anyTest as TestFn<{
 	sinon: sinonGlobal.SinonSandbox;
@@ -34,46 +33,6 @@ test.beforeEach(async (t) => {
 test.afterEach.always((t) => {
 	t.context.sinon.restore();
 	esmock.purge(t.context.ContextModule);
-});
-
-test("Update roots", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const inputPathAllowedInitially = path.join(absoluteBasePath, "root1", "foo");
-	const inputPathAllowedAfterUpdate = path.join(absoluteBasePath, "root3", "foo");
-	const inputPathNeverAllowed = path.join(absoluteBasePath, "root5", "foo");
-	const rootPath1 = path.join(absoluteBasePath, "root1");
-	const rootPath2 = path.join(absoluteBasePath, "root2");
-	const context = new Context();
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	context.setRoots([
-		{uri: pathToFileURL(rootPath1).toString()},
-		{uri: pathToFileURL(rootPath2).toString()},
-	]);
-
-	t.truthy(await context.normalizePath(inputPathAllowedInitially));
-	await t.throwsAsync(() => context.normalizePath(inputPathNeverAllowed), {
-		instanceOf: InvalidInputError,
-		message: /Path must be inside an allowed root path/,
-	});
-
-	const rootPath3 = path.join(absoluteBasePath, "root3");
-	const rootPath4 = path.join(absoluteBasePath, "root4");
-	context.setRoots([
-		{uri: pathToFileURL(rootPath3).toString()},
-		{uri: pathToFileURL(rootPath4).toString()},
-	]);
-
-	await t.throwsAsync(() => context.normalizePath(inputPathAllowedInitially), {
-		instanceOf: InvalidInputError,
-		message: /Path must be inside an allowed root path/,
-	});
-	await t.throwsAsync(() => context.normalizePath(inputPathNeverAllowed), {
-		instanceOf: InvalidInputError,
-		message: /Path must be inside an allowed root path/,
-	});
-	t.truthy(await context.normalizePath(inputPathAllowedAfterUpdate));
 });
 
 test("normalizePath returns resolved path", async (t) => {
@@ -118,177 +77,6 @@ test("normalizePath throws error for relative path", async (t) => {
 	});
 });
 
-test("normalizePath allows any path when no roots are configured", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const inputPath = path.join(absoluteBasePath, "any", "absolute", "path");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	const result = await context.normalizePath(inputPath);
-
-	t.is(result, inputPath);
-});
-
-test("normalizePath allows path inside configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root", "subdir", "file.txt");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const result = await context.normalizePath(inputPath);
-
-	t.is(result, inputPath);
-});
-test("normalizePath allows path equal to configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root"); // Equal to root
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const result = await context.normalizePath(inputPath);
-
-	t.is(result, inputPath);
-});
-
-test("normalizePath allows resolved path inside configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "outside", "..", "allowed", "root", "subdir", "file.txt");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const result = await context.normalizePath(inputPath);
-
-	t.is(result, path.join(absoluteBasePath, "allowed", "root", "subdir", "file.txt"));
-});
-
-test("normalizePath throws error for path outside configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "outside", "root", "file.txt");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
-	t.true(error instanceof InvalidInputError);
-	t.true(error?.message.includes("Path must be inside an allowed root path"));
-	t.true(error?.message.includes(inputPath));
-	t.true(error?.message.includes(rootPath));
-	t.false(realpathStub.calledOnce, "realpath did not get invoked for path outside allowed roots");
-});
-
-test("normalizePath throws error for resolved path outside configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root", "..", "outside", "file.txt");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
-	t.true(error instanceof InvalidInputError);
-	t.true(error?.message.includes("Path must be inside an allowed root path"));
-	t.true(error?.message.includes(inputPath));
-	t.true(error?.message.includes(rootPath));
-});
-
-test("normalizePath throws error for symlink (realpath) outside configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root", "symlink", "file.txt");
-	// Simulate symlink resolution through realpath
-	const resolvedPath = path.join(absoluteBasePath, "outside", "root", "file.txt");
-	realpathStub.resolves(resolvedPath);
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
-	t.true(error instanceof InvalidInputError);
-	t.true(error?.message.includes("Path must be inside an allowed root path"));
-	t.true(error?.message.includes(inputPath));
-	t.true(error?.message.includes(rootPath));
-});
-
-test("normalizePath throws error for path outside (but starting with) configured root", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath = path.join(absoluteBasePath, "allowed", "root");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root_secret_path", "file.txt");
-	realpathStub.resolvesArg(0); // Simulate realpath returning the input path
-
-	const context = new Context();
-	context.setRoots([{uri: pathToFileURL(rootPath).toString()}]);
-
-	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
-	t.true(error instanceof InvalidInputError);
-	t.true(error?.message.includes("Path must be inside an allowed root path"));
-	t.true(error?.message.includes(inputPath));
-	t.true(error?.message.includes(rootPath));
-	t.false(realpathStub.calledOnce, "realpath did not get invoked for path outside allowed roots");
-});
-
-test("normalizePath allows path inside any of multiple configured roots", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath1 = path.join(absoluteBasePath, "allowed", "root1");
-	const rootPath2 = path.join(absoluteBasePath, "allowed", "root2");
-	const inputPath = path.join(absoluteBasePath, "allowed", "root2", "subdir", "file.txt");
-	const resolvedPath = path.join(absoluteBasePath, "allowed", "root2", "subdir", "file.txt");
-	realpathStub.resolves(resolvedPath);
-
-	const context = new Context();
-	context.setRoots([
-		{uri: pathToFileURL(rootPath1).toString()},
-		{uri: pathToFileURL(rootPath2).toString()},
-	]);
-
-	const result = await context.normalizePath(inputPath);
-
-	t.is(result, resolvedPath);
-});
-
-test("normalizePath throws error when path is outside all configured roots", async (t) => {
-	const {Context, realpathStub} = t.context;
-
-	const rootPath1 = path.join(absoluteBasePath, "allowed", "root1");
-	const rootPath2 = path.join(absoluteBasePath, "allowed", "root2");
-	const inputPath = path.join(absoluteBasePath, "outside", "all", "roots", "file.txt");
-	const resolvedPath = path.join(absoluteBasePath, "outside", "all", "roots", "file.txt");
-	realpathStub.resolves(resolvedPath);
-
-	const context = new Context();
-	context.setRoots([
-		{uri: pathToFileURL(rootPath1).toString()},
-		{uri: pathToFileURL(rootPath2).toString()},
-	]);
-
-	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
-	t.true(error instanceof InvalidInputError);
-	t.true(error?.message.includes("Path must be inside an allowed root path"));
-	t.true(error?.message.includes(inputPath));
-	t.true(error?.message.includes(rootPath1));
-	t.true(error?.message.includes(rootPath2));
-});
-
 test("normalizePath throws error when realpath fails", async (t) => {
 	const {Context, realpathStub} = t.context;
 
@@ -300,22 +88,4 @@ test("normalizePath throws error when realpath fails", async (t) => {
 
 	const error = await t.throwsAsync(() => context.normalizePath(inputPath));
 	t.is(error, fsError);
-});
-
-test("isInsideRoots compares Windows drive letter case-insensitively", (t) => {
-	const {Context} = t.context;
-	const context = new Context();
-
-	// Only a meaningful assertion on Windows. On other platforms just mark as passed.
-	if (process.platform !== "win32") {
-		t.pass();
-		return;
-	}
-
-	// Lowercase root, uppercase path
-	const lowerRoot = "c:\\caseinsensitive\\root";
-	context.setRoots([{uri: pathToFileURL(lowerRoot).toString()}]);
-
-	const upperPath = "C:\\CaseInsensitive\\Root\\subdir\\file.txt";
-	t.true(context.isInsideRoots(upperPath));
 });

--- a/test/lib/server.ts
+++ b/test/lib/server.ts
@@ -1,5 +1,5 @@
 import anyTest, {TestFn} from "ava";
-import sinonGlobal, {SinonStub} from "sinon";
+import sinonGlobal from "sinon";
 import esmock from "esmock";
 import {Transport} from "@modelcontextprotocol/sdk/shared/transport.js";
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -7,14 +7,12 @@ import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
 import {PKG_VERSION} from "../../src/utils.js";
 
 const test = anyTest as TestFn<{
-	simulateServerInitialized: () => Promise<void>;
 	sinon: sinonGlobal.SinonSandbox;
 	Server: typeof import("../../src/server.js").default;
 	mockMcpServer: sinonGlobal.SinonStubbedInstance<McpServer>;
 	mockTransport: sinonGlobal.SinonStubbedInstance<Transport>;
 	constructorStub: sinonGlobal.SinonStub;
 	contextConstructorStub: sinonGlobal.SinonStub;
-	contextSetRootsStub: sinonGlobal.SinonStub;
 	originalEnv: NodeJS.ProcessEnv;
 	registerToolsStub: sinonGlobal.SinonStub;
 }>;
@@ -28,37 +26,7 @@ test.beforeEach(async (t) => {
 	// Create mock for McpServer
 	const mockMcpServer = t.context.sinon.createStubInstance(McpServer);
 	// @ts-expect-error stub read-only property "server"
-	mockMcpServer.server = {
-		listRoots: t.context.sinon.stub()
-			.onFirstCall()
-			.resolves({
-				roots: [{
-					name: "my-root",
-					uri: "file://test-root",
-				}],
-			})
-			.onSecondCall()
-			.resolves({
-				roots: [{
-					name: "my-root",
-					uri: "file://changed-test-root",
-				}, {
-					name: "my-other-root",
-					uri: "file://other-test-root",
-				}],
-			}),
-		setNotificationHandler: t.context.sinon.stub(),
-		getClientCapabilities: () => ({
-			roots: {
-				listChanged: true,
-			},
-		}),
-	};
-	t.context.simulateServerInitialized = async () => {
-		// @ts-expect-error - Types are not compatible with the mock
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await mockMcpServer.server.oninitialized();
-	};
+	mockMcpServer.server = {};
 	t.context.mockMcpServer = mockMcpServer;
 
 	// Create mock for Transport
@@ -72,10 +40,7 @@ test.beforeEach(async (t) => {
 
 	t.context.registerToolsStub = t.context.sinon.stub();
 
-	t.context.contextSetRootsStub = t.context.sinon.stub();
-	t.context.contextConstructorStub = t.context.sinon.stub().returns({
-		setRoots: t.context.contextSetRootsStub,
-	});
+	t.context.contextConstructorStub = t.context.sinon.stub().returns({});
 	// Import the Server class with mocked dependencies
 	const {default: Server} = await esmock("../../src/server.js", {
 		"@modelcontextprotocol/sdk/server/mcp.js": {
@@ -133,7 +98,7 @@ test.serial("Context is created with correct parameters", (t) => {
 });
 
 test("connect method connects the server with default transport", async (t) => {
-	const {Server, mockMcpServer, simulateServerInitialized, contextSetRootsStub} = t.context;
+	const {Server, mockMcpServer} = t.context;
 	// Create a new server instance
 	const server = new Server();
 
@@ -146,34 +111,6 @@ test("connect method connects the server with default transport", async (t) => {
 	// Verify connect was called with StdioServerTransport
 	t.true(mockMcpServer.connect.calledOnce);
 	t.true(mockMcpServer.connect.firstCall.args[0] instanceof StdioServerTransport);
-
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	const listRoots = mockMcpServer.server.listRoots as SinonStub;
-	t.true(listRoots.notCalled);
-
-	await simulateServerInitialized();
-
-	t.true(listRoots.calledOnce);
-	t.true(contextSetRootsStub.calledOnce);
-	t.deepEqual(contextSetRootsStub.firstCall.args[0], [{
-		name: "my-root",
-		uri: "file://test-root",
-	}]);
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	const setNotificationHandler = mockMcpServer.server.setNotificationHandler as SinonStub;
-	t.true(setNotificationHandler.calledOnce);
-	// Trigger notification handler
-	await setNotificationHandler.firstCall.args[1]({method: "notifications/roots/list_changed"});
-	t.true(listRoots.calledTwice);
-
-	t.true(contextSetRootsStub.calledTwice);
-	t.deepEqual(contextSetRootsStub.secondCall.args[0], [{
-		name: "my-root",
-		uri: "file://changed-test-root",
-	}, {
-		name: "my-other-root",
-		uri: "file://other-test-root",
-	}]);
 });
 
 test("connect method connects the server with custom transport", async (t) => {


### PR DESCRIPTION
The MCP "roots" feature has been deprecated by SEP-2577 (roots capability, listRoots request, and roots/list_changed notification).

Remove the roots protocol wiring from the server and the roots-based path restriction it fed in Context. normalizePath now only validates that a path is absolute and resolves it via realpath, without an allowed-roots boundary.

See: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/seps/2577-deprecate-roots-sampling-and-logging.md

BREAKING CHANGE: The roots-based path restriction is removed. Tools no longer limit file access to client-provided roots and now accept any absolute path.

